### PR TITLE
Dashboard cleanup and quick action fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 Node version manager - [NVM](https://github.com/nvm-sh/nvm) to easily install and manage node versions
 
 ## Local Development
-Simply, run `nvm use && npm i && npm run dev` and it will start a local server for you to develop on, it will also watch for changes and reload the page for you. 
+Simply, run `nvm use && npm i && npm run dev` and it will start a local server for you to develop on, it will also watch for changes and reload the page for you.
+
+### Required Environment Variables
+Set the following values in your `.env` file before running the dashboard:
+
+```
+VITE_HA_URL=<https://your-homeassistant>
+VITE_HA_TOKEN=<long-lived token>
+```
+
+The token is optional if you only need read-only access.
 
 ## Dependencies
 
@@ -92,3 +102,5 @@ export default tseslint.config({
   },
 })
 ```
+## Contributing
+New cards can be added using the component registry. Wrap your component in `useRegisterComponent` with a unique id, supported types, and a display check. See `ComponentRegistry.tsx` for examples.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,22 +1,18 @@
-import tseslint from '@typescript-eslint/eslint-plugin'
-import globals from 'globals'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+import tseslint from 'typescript-eslint';
+import globals from 'globals';
+import reactHooks from 'eslint-plugin-react-hooks';
+import reactRefresh from 'eslint-plugin-react-refresh';
+import reactX from 'eslint-plugin-react-x';
+import reactDom from 'eslint-plugin-react-dom';
 
 export default tseslint.config(
   // Common options; e.g. folders/files to ignore
   {
-    ignores: ['dist']
+    ignores: ['dist'],
   },
   // Base configuration
   {
-    extends: [
-      ...tseslint.configs.recommendedTypeChecked,
-      ...tseslint.configs.strictTypeChecked,
-      ...tseslint.configs.stylisticTypeChecked,
-    ],
+    extends: [...tseslint.configs.recommendedTypeChecked, ...tseslint.configs.strictTypeChecked, ...tseslint.configs.stylisticTypeChecked],
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
       parserOptions: {
@@ -38,13 +34,10 @@ export default tseslint.config(
     rules: {
       // Recommended React Hooks rules and fast refresh checks
       ...reactHooks.configs.recommended.rules,
-      'react-refresh/only-export-components': [
-        'warn',
-        { allowConstantExport: true },
-      ],
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
       // New plugin rules (if you want extra linting)
       ...reactX.configs['recommended-typescript'].rules,
       ...reactDom.configs.recommended.rules,
     },
   }
-)
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,9 @@
       "dependencies": {
         "@hakit/components": "^5.0.9",
         "@hakit/core": "^5.0.9",
-        "framer-motion": "^12.7.2",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-error-boundary": "^6.0.0"
+        "react-error-boundary": "^5.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -25,8 +24,10 @@
         "chalk": "^5.4.1",
         "dotenv": "^16.5.0",
         "eslint": "^9.21.0",
+        "eslint-plugin-react-dom": "^1.52.2",
         "eslint-plugin-react-hooks": "^5.1.0",
         "eslint-plugin-react-refresh": "^0.4.19",
+        "eslint-plugin-react-x": "^1.52.2",
         "globals": "^16.0.0",
         "node-scp": "^0.0.25",
         "prettier": "^3.5.3",
@@ -903,6 +904,849 @@
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint-react/ast": {
+      "version": "1.52.2",
+      "resolved": "https://registry.npmjs.org/@eslint-react/ast/-/ast-1.52.2.tgz",
+      "integrity": "sha512-L0Tbbzx5l7JHgkQ1TqPWQuZ4+PsXDcgtt3056FOYqstUrDRG+5ylm7h3gEWu98I3FDdgLS8q9dOzz0PGgwZCTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/eff": "1.52.2",
+        "@typescript-eslint/types": "^8.34.0",
+        "@typescript-eslint/typescript-estree": "^8.34.0",
+        "@typescript-eslint/utils": "^8.34.0",
+        "string-ts": "^2.2.1",
+        "ts-pattern": "^5.7.1"
+      },
+      "engines": {
+        "bun": ">=1.0.15",
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@eslint-react/ast/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.35.1.tgz",
+      "integrity": "sha512-s/Bpd4i7ht2934nG+UoSPlYXd08KYz3bmjLEb7Ye1UVob0d1ENiT3lY8bsCmik4RqfSbPw9xJJHbugpPpP5JUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@eslint-react/ast/node_modules/@typescript-eslint/types": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.1.tgz",
+      "integrity": "sha512-q/O04vVnKHfrrhNAscndAn1tuQhIkwqnaW+eu5waD5IPts2eX1dgJxgqcPx5BX109/qAz7IG6VrEPTOYKCNfRQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@eslint-react/ast/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.1.tgz",
+      "integrity": "sha512-Vvpuvj4tBxIka7cPs6Y1uvM7gJgdF5Uu9F+mBJBPY4MhvjrjWGK4H0lVgLJd/8PWZ23FTqsaJaLEkBCFUk8Y9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.35.1",
+        "@typescript-eslint/tsconfig-utils": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@eslint-react/ast/node_modules/@typescript-eslint/utils": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.35.1.tgz",
+      "integrity": "sha512-lhnwatFmOFcazAsUm3ZnZFpXSxiwoa1Lj50HphnDe1Et01NF4+hrdXONSUHIcbVu2eFb1bAf+5yjXkGVkXBKAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/typescript-estree": "8.35.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@eslint-react/ast/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.1.tgz",
+      "integrity": "sha512-VRwixir4zBWCSTP/ljEo091lbpypz57PoeAQ9imjG+vbeof9LplljsL1mos4ccG6H9IjfrVGM359RozUnuFhpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.35.1",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@eslint-react/ast/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@eslint-react/ast/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@eslint-react/ast/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@eslint-react/core": {
+      "version": "1.52.2",
+      "resolved": "https://registry.npmjs.org/@eslint-react/core/-/core-1.52.2.tgz",
+      "integrity": "sha512-FpxKZJHlf3zXETNL+WQP/SoYuVQNheWm1iDgW68RyHygD8mzk9CnVLDgjMrfmh2n0eaOqnWCL/IC2YzD6VpYOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "1.52.2",
+        "@eslint-react/eff": "1.52.2",
+        "@eslint-react/kit": "1.52.2",
+        "@eslint-react/shared": "1.52.2",
+        "@eslint-react/var": "1.52.2",
+        "@typescript-eslint/scope-manager": "^8.34.0",
+        "@typescript-eslint/type-utils": "^8.34.0",
+        "@typescript-eslint/types": "^8.34.0",
+        "@typescript-eslint/utils": "^8.34.0",
+        "birecord": "^0.1.1",
+        "ts-pattern": "^5.7.1"
+      },
+      "engines": {
+        "bun": ">=1.0.15",
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@eslint-react/core/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.35.1.tgz",
+      "integrity": "sha512-s/Bpd4i7ht2934nG+UoSPlYXd08KYz3bmjLEb7Ye1UVob0d1ENiT3lY8bsCmik4RqfSbPw9xJJHbugpPpP5JUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@eslint-react/core/node_modules/@typescript-eslint/type-utils": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.35.1.tgz",
+      "integrity": "sha512-HOrUBlfVRz5W2LIKpXzZoy6VTZzMu2n8q9C2V/cFngIC5U1nStJgv0tMV4sZPzdf4wQm9/ToWUFPMN9Vq9VJQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "8.35.1",
+        "@typescript-eslint/utils": "8.35.1",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@eslint-react/core/node_modules/@typescript-eslint/types": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.1.tgz",
+      "integrity": "sha512-q/O04vVnKHfrrhNAscndAn1tuQhIkwqnaW+eu5waD5IPts2eX1dgJxgqcPx5BX109/qAz7IG6VrEPTOYKCNfRQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@eslint-react/core/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.1.tgz",
+      "integrity": "sha512-Vvpuvj4tBxIka7cPs6Y1uvM7gJgdF5Uu9F+mBJBPY4MhvjrjWGK4H0lVgLJd/8PWZ23FTqsaJaLEkBCFUk8Y9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.35.1",
+        "@typescript-eslint/tsconfig-utils": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@eslint-react/core/node_modules/@typescript-eslint/utils": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.35.1.tgz",
+      "integrity": "sha512-lhnwatFmOFcazAsUm3ZnZFpXSxiwoa1Lj50HphnDe1Et01NF4+hrdXONSUHIcbVu2eFb1bAf+5yjXkGVkXBKAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/typescript-estree": "8.35.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@eslint-react/core/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.1.tgz",
+      "integrity": "sha512-VRwixir4zBWCSTP/ljEo091lbpypz57PoeAQ9imjG+vbeof9LplljsL1mos4ccG6H9IjfrVGM359RozUnuFhpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.35.1",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@eslint-react/core/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@eslint-react/core/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@eslint-react/core/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@eslint-react/eff": {
+      "version": "1.52.2",
+      "resolved": "https://registry.npmjs.org/@eslint-react/eff/-/eff-1.52.2.tgz",
+      "integrity": "sha512-YBPE2J1+PfXrR9Ct+9rQsw8uRU06zHopI508cfj0usaIBf3hz18V2GoRTVhsjniP0QbvKQdHzyPmmS/B6uyMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "bun": ">=1.0.15",
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@eslint-react/kit": {
+      "version": "1.52.2",
+      "resolved": "https://registry.npmjs.org/@eslint-react/kit/-/kit-1.52.2.tgz",
+      "integrity": "sha512-k0cSgFnPlDPI1xyRzHjEWIapLG0zCy7mx1HBLg5wuKf/zzSh3iNFId53xMebR05vM2k9YH63gsvTwRkGx/77Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/eff": "1.52.2",
+        "@typescript-eslint/utils": "^8.34.0",
+        "ts-pattern": "^5.7.1",
+        "zod": "^3.25.63"
+      },
+      "engines": {
+        "bun": ">=1.0.15",
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@eslint-react/kit/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.35.1.tgz",
+      "integrity": "sha512-s/Bpd4i7ht2934nG+UoSPlYXd08KYz3bmjLEb7Ye1UVob0d1ENiT3lY8bsCmik4RqfSbPw9xJJHbugpPpP5JUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@eslint-react/kit/node_modules/@typescript-eslint/types": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.1.tgz",
+      "integrity": "sha512-q/O04vVnKHfrrhNAscndAn1tuQhIkwqnaW+eu5waD5IPts2eX1dgJxgqcPx5BX109/qAz7IG6VrEPTOYKCNfRQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@eslint-react/kit/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.1.tgz",
+      "integrity": "sha512-Vvpuvj4tBxIka7cPs6Y1uvM7gJgdF5Uu9F+mBJBPY4MhvjrjWGK4H0lVgLJd/8PWZ23FTqsaJaLEkBCFUk8Y9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.35.1",
+        "@typescript-eslint/tsconfig-utils": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@eslint-react/kit/node_modules/@typescript-eslint/utils": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.35.1.tgz",
+      "integrity": "sha512-lhnwatFmOFcazAsUm3ZnZFpXSxiwoa1Lj50HphnDe1Et01NF4+hrdXONSUHIcbVu2eFb1bAf+5yjXkGVkXBKAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/typescript-estree": "8.35.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@eslint-react/kit/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.1.tgz",
+      "integrity": "sha512-VRwixir4zBWCSTP/ljEo091lbpypz57PoeAQ9imjG+vbeof9LplljsL1mos4ccG6H9IjfrVGM359RozUnuFhpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.35.1",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@eslint-react/kit/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@eslint-react/kit/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@eslint-react/kit/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@eslint-react/shared": {
+      "version": "1.52.2",
+      "resolved": "https://registry.npmjs.org/@eslint-react/shared/-/shared-1.52.2.tgz",
+      "integrity": "sha512-YHysVcCfmBoxt2+6Ao4HdLPUYNSem70gy+0yzOQvlQFSsGhh+uifQ68SSa/2uJBWfNUm9xQlyDsr2raeO4BlgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/eff": "1.52.2",
+        "@eslint-react/kit": "1.52.2",
+        "@typescript-eslint/utils": "^8.34.0",
+        "ts-pattern": "^5.7.1",
+        "zod": "^3.25.63"
+      },
+      "engines": {
+        "bun": ">=1.0.15",
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@eslint-react/shared/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.35.1.tgz",
+      "integrity": "sha512-s/Bpd4i7ht2934nG+UoSPlYXd08KYz3bmjLEb7Ye1UVob0d1ENiT3lY8bsCmik4RqfSbPw9xJJHbugpPpP5JUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@eslint-react/shared/node_modules/@typescript-eslint/types": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.1.tgz",
+      "integrity": "sha512-q/O04vVnKHfrrhNAscndAn1tuQhIkwqnaW+eu5waD5IPts2eX1dgJxgqcPx5BX109/qAz7IG6VrEPTOYKCNfRQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@eslint-react/shared/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.1.tgz",
+      "integrity": "sha512-Vvpuvj4tBxIka7cPs6Y1uvM7gJgdF5Uu9F+mBJBPY4MhvjrjWGK4H0lVgLJd/8PWZ23FTqsaJaLEkBCFUk8Y9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.35.1",
+        "@typescript-eslint/tsconfig-utils": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@eslint-react/shared/node_modules/@typescript-eslint/utils": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.35.1.tgz",
+      "integrity": "sha512-lhnwatFmOFcazAsUm3ZnZFpXSxiwoa1Lj50HphnDe1Et01NF4+hrdXONSUHIcbVu2eFb1bAf+5yjXkGVkXBKAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/typescript-estree": "8.35.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@eslint-react/shared/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.1.tgz",
+      "integrity": "sha512-VRwixir4zBWCSTP/ljEo091lbpypz57PoeAQ9imjG+vbeof9LplljsL1mos4ccG6H9IjfrVGM359RozUnuFhpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.35.1",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@eslint-react/shared/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@eslint-react/shared/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@eslint-react/shared/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@eslint-react/var": {
+      "version": "1.52.2",
+      "resolved": "https://registry.npmjs.org/@eslint-react/var/-/var-1.52.2.tgz",
+      "integrity": "sha512-/7IYMPsmO0tIYqkqAVnkqB4eXeVBvgBL/a9hcGCO2eUSzslYzQHSzNPhIoPLD9HXng+0CWlT+KupOFIqP9a26A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "1.52.2",
+        "@eslint-react/eff": "1.52.2",
+        "@typescript-eslint/scope-manager": "^8.34.0",
+        "@typescript-eslint/types": "^8.34.0",
+        "@typescript-eslint/utils": "^8.34.0",
+        "string-ts": "^2.2.1",
+        "ts-pattern": "^5.7.1"
+      },
+      "engines": {
+        "bun": ">=1.0.15",
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@eslint-react/var/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.35.1.tgz",
+      "integrity": "sha512-s/Bpd4i7ht2934nG+UoSPlYXd08KYz3bmjLEb7Ye1UVob0d1ENiT3lY8bsCmik4RqfSbPw9xJJHbugpPpP5JUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@eslint-react/var/node_modules/@typescript-eslint/types": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.1.tgz",
+      "integrity": "sha512-q/O04vVnKHfrrhNAscndAn1tuQhIkwqnaW+eu5waD5IPts2eX1dgJxgqcPx5BX109/qAz7IG6VrEPTOYKCNfRQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@eslint-react/var/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.1.tgz",
+      "integrity": "sha512-Vvpuvj4tBxIka7cPs6Y1uvM7gJgdF5Uu9F+mBJBPY4MhvjrjWGK4H0lVgLJd/8PWZ23FTqsaJaLEkBCFUk8Y9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.35.1",
+        "@typescript-eslint/tsconfig-utils": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@eslint-react/var/node_modules/@typescript-eslint/utils": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.35.1.tgz",
+      "integrity": "sha512-lhnwatFmOFcazAsUm3ZnZFpXSxiwoa1Lj50HphnDe1Et01NF4+hrdXONSUHIcbVu2eFb1bAf+5yjXkGVkXBKAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/typescript-estree": "8.35.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@eslint-react/var/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.1.tgz",
+      "integrity": "sha512-VRwixir4zBWCSTP/ljEo091lbpypz57PoeAQ9imjG+vbeof9LplljsL1mos4ccG6H9IjfrVGM359RozUnuFhpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.35.1",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@eslint-react/var/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@eslint-react/var/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@eslint-react/var/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@eslint/config-array": {
@@ -2204,6 +3048,42 @@
         "typescript": ">=4.8.4 <5.9.0"
       }
     },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.35.1.tgz",
+      "integrity": "sha512-VYxn/5LOpVxADAuP3NrnxxHYfzVtQzLKeldIhDhzC8UHaiQvYlXvKuVho1qLduFbJjjy5U5bkGwa3rUGUb1Q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.35.1",
+        "@typescript-eslint/types": "^8.35.1",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service/node_modules/@typescript-eslint/types": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.1.tgz",
+      "integrity": "sha512-q/O04vVnKHfrrhNAscndAn1tuQhIkwqnaW+eu5waD5IPts2eX1dgJxgqcPx5BX109/qAz7IG6VrEPTOYKCNfRQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.32.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.32.1.tgz",
@@ -2220,6 +3100,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.35.1.tgz",
+      "integrity": "sha512-K5/U9VmT9dTHoNowWZpz+/TObS3xqC5h0xAIjXPw+MNcKV9qg6eSatEnmeAwkjHijhACH0/N7bkhKvbt1+DXWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
@@ -2541,6 +3438,13 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "node_modules/birecord": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/birecord/-/birecord-0.1.1.tgz",
+      "integrity": "sha512-VUpsf/qykW0heRlC8LooCq28Kxn3mAqKohhDG/49rrsQ1dT1CXyj/pgXS+5BSRzFTR/3DyIBOqQOrGyZOh71Aw==",
+      "dev": true,
+      "license": "(MIT OR Apache-2.0)"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2684,6 +3588,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2996,6 +3907,185 @@
         }
       }
     },
+    "node_modules/eslint-plugin-react-dom": {
+      "version": "1.52.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-dom/-/eslint-plugin-react-dom-1.52.2.tgz",
+      "integrity": "sha512-HDwQTwGfJTFAa4x0Bf9NH/TVHULEFjI0/vBNhkZt7JAHFb7v+SrhlXGUIIKfQTPHHJIAQZm8v3yzc5g/NlCokA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "1.52.2",
+        "@eslint-react/core": "1.52.2",
+        "@eslint-react/eff": "1.52.2",
+        "@eslint-react/kit": "1.52.2",
+        "@eslint-react/shared": "1.52.2",
+        "@eslint-react/var": "1.52.2",
+        "@typescript-eslint/scope-manager": "^8.34.0",
+        "@typescript-eslint/types": "^8.34.0",
+        "@typescript-eslint/utils": "^8.34.0",
+        "compare-versions": "^6.1.1",
+        "string-ts": "^2.2.1",
+        "ts-pattern": "^5.7.1"
+      },
+      "engines": {
+        "bun": ">=1.0.15",
+        "node": ">=18.18.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": "^4.9.5 || ^5.3.3"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": false
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-react-dom/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.35.1.tgz",
+      "integrity": "sha512-s/Bpd4i7ht2934nG+UoSPlYXd08KYz3bmjLEb7Ye1UVob0d1ENiT3lY8bsCmik4RqfSbPw9xJJHbugpPpP5JUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-react-dom/node_modules/@typescript-eslint/types": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.1.tgz",
+      "integrity": "sha512-q/O04vVnKHfrrhNAscndAn1tuQhIkwqnaW+eu5waD5IPts2eX1dgJxgqcPx5BX109/qAz7IG6VrEPTOYKCNfRQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-react-dom/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.1.tgz",
+      "integrity": "sha512-Vvpuvj4tBxIka7cPs6Y1uvM7gJgdF5Uu9F+mBJBPY4MhvjrjWGK4H0lVgLJd/8PWZ23FTqsaJaLEkBCFUk8Y9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.35.1",
+        "@typescript-eslint/tsconfig-utils": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-dom/node_modules/@typescript-eslint/utils": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.35.1.tgz",
+      "integrity": "sha512-lhnwatFmOFcazAsUm3ZnZFpXSxiwoa1Lj50HphnDe1Et01NF4+hrdXONSUHIcbVu2eFb1bAf+5yjXkGVkXBKAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/typescript-estree": "8.35.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-dom/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.1.tgz",
+      "integrity": "sha512-VRwixir4zBWCSTP/ljEo091lbpypz57PoeAQ9imjG+vbeof9LplljsL1mos4ccG6H9IjfrVGM359RozUnuFhpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.35.1",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-react-dom/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-dom/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-plugin-react-dom/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
@@ -3018,6 +4108,215 @@
         "eslint": ">=8.40"
       }
     },
+    "node_modules/eslint-plugin-react-x": {
+      "version": "1.52.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-x/-/eslint-plugin-react-x-1.52.2.tgz",
+      "integrity": "sha512-Pxpf3YxCUcNgzJVT6blAJ2KvLX32pUxtXndaCZoTdiytFw/H9OZKq4Qczxx/Lpo9Ri5rm4FbIZL3BfL/HGmzBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "1.52.2",
+        "@eslint-react/core": "1.52.2",
+        "@eslint-react/eff": "1.52.2",
+        "@eslint-react/kit": "1.52.2",
+        "@eslint-react/shared": "1.52.2",
+        "@eslint-react/var": "1.52.2",
+        "@typescript-eslint/scope-manager": "^8.34.0",
+        "@typescript-eslint/type-utils": "^8.34.0",
+        "@typescript-eslint/types": "^8.34.0",
+        "@typescript-eslint/utils": "^8.34.0",
+        "compare-versions": "^6.1.1",
+        "is-immutable-type": "^5.0.1",
+        "string-ts": "^2.2.1",
+        "ts-pattern": "^5.7.1"
+      },
+      "engines": {
+        "bun": ">=1.0.15",
+        "node": ">=18.18.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "ts-api-utils": "^2.1.0",
+        "typescript": "^4.9.5 || ^5.3.3"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": false
+        },
+        "ts-api-utils": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-react-x/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.35.1.tgz",
+      "integrity": "sha512-s/Bpd4i7ht2934nG+UoSPlYXd08KYz3bmjLEb7Ye1UVob0d1ENiT3lY8bsCmik4RqfSbPw9xJJHbugpPpP5JUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-react-x/node_modules/@typescript-eslint/type-utils": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.35.1.tgz",
+      "integrity": "sha512-HOrUBlfVRz5W2LIKpXzZoy6VTZzMu2n8q9C2V/cFngIC5U1nStJgv0tMV4sZPzdf4wQm9/ToWUFPMN9Vq9VJQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "8.35.1",
+        "@typescript-eslint/utils": "8.35.1",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-x/node_modules/@typescript-eslint/types": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.1.tgz",
+      "integrity": "sha512-q/O04vVnKHfrrhNAscndAn1tuQhIkwqnaW+eu5waD5IPts2eX1dgJxgqcPx5BX109/qAz7IG6VrEPTOYKCNfRQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-react-x/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.1.tgz",
+      "integrity": "sha512-Vvpuvj4tBxIka7cPs6Y1uvM7gJgdF5Uu9F+mBJBPY4MhvjrjWGK4H0lVgLJd/8PWZ23FTqsaJaLEkBCFUk8Y9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.35.1",
+        "@typescript-eslint/tsconfig-utils": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/visitor-keys": "8.35.1",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-x/node_modules/@typescript-eslint/utils": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.35.1.tgz",
+      "integrity": "sha512-lhnwatFmOFcazAsUm3ZnZFpXSxiwoa1Lj50HphnDe1Et01NF4+hrdXONSUHIcbVu2eFb1bAf+5yjXkGVkXBKAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.35.1",
+        "@typescript-eslint/types": "8.35.1",
+        "@typescript-eslint/typescript-estree": "8.35.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-x/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.35.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.1.tgz",
+      "integrity": "sha512-VRwixir4zBWCSTP/ljEo091lbpypz57PoeAQ9imjG+vbeof9LplljsL1mos4ccG6H9IjfrVGM359RozUnuFhpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.35.1",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-react-x/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react-x/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-plugin-react-x/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
@@ -3035,10 +4334,11 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -3256,33 +4556,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true
-    },
-    "node_modules/framer-motion": {
-      "version": "12.12.2",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.12.2.tgz",
-      "integrity": "sha512-qCszZCiGWkilL40E3VuhIJJC/CS3SIBl2IHyGK8FU30nOUhTmhBNWPrNFyozAWH/bXxwzi19vJHIGVdALF0LCg==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-dom": "^12.12.1",
-        "motion-utils": "^12.12.1",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -3517,6 +4790,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-immutable-type": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/is-immutable-type/-/is-immutable-type-5.0.1.tgz",
+      "integrity": "sha512-LkHEOGVZZXxGl8vDs+10k3DvP++SEoYEAJLRk6buTFi6kD7QekThV7xHS0j6gpnUCQ0zpud/gMDGiV4dQneLTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@typescript-eslint/type-utils": "^8.0.0",
+        "ts-api-utils": "^2.0.0",
+        "ts-declaration-location": "^1.0.4"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "typescript": ">=4.7.4"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3735,21 +5024,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/motion-dom": {
-      "version": "12.12.1",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.12.1.tgz",
-      "integrity": "sha512-GXq/uUbZBEiFFE+K1Z/sxdPdadMdfJ/jmBALDfIuHGi0NmtealLOfH9FqT+6aNPgVx8ilq0DtYmyQlo6Uj9LKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-utils": "^12.12.1"
-      }
-    },
-    "node_modules/motion-utils": {
-      "version": "12.12.1",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.12.1.tgz",
-      "integrity": "sha512-f9qiqUHm7hWSLlNW8gS9pisnsN7CRFRD58vNjptKdsqFLpkVnX00TNeD6Q0d27V9KzT7ySFyK1TZ/DShfVOv6w==",
-      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -4106,9 +5380,9 @@
       }
     },
     "node_modules/react-error-boundary": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-6.0.0.tgz",
-      "integrity": "sha512-gdlJjD7NWr0IfkPlaREN2d9uUZUlksrfOx7SX62VRerwXbMY6ftGCIZua1VG1aXFNOimhISsTq+Owp725b9SiA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-5.0.0.tgz",
+      "integrity": "sha512-tnjAxG+IkpLephNcePNA7v6F/QpWLH8He65+DmedchDwg162JZqx4NmbXj0mlAYVVEd81OW7aFhmbsScYfiAFQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5"
@@ -4503,6 +5777,13 @@
         "stacktrace-gps": "^3.0.4"
       }
     },
+    "node_modules/string-ts": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/string-ts/-/string-ts-2.2.1.tgz",
+      "integrity": "sha512-Q2u0gko67PLLhbte5HmPfdOjNvUKbKQM+mCNQae6jE91DmoFHY6HH9GcdqCeNx87DZ2KKjiFxmA0R/42OneGWw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -4656,16 +5937,60 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-declaration-location": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/ts-declaration-location/-/ts-declaration-location-1.0.7.tgz",
+      "integrity": "sha512-EDyGAwH1gO0Ausm9gV6T2nUvBgXT5kGoCMJPllOaooZ+4VvJiKBdZE7wK18N1deEowhcUptS+5GXZK8U/fvpwA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "ko-fi",
+          "url": "https://ko-fi.com/rebeccastevens"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/ts-declaration-location"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "picomatch": "^4.0.2"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.0.0"
+      }
+    },
+    "node_modules/ts-declaration-location/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/ts-easing": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
       "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==",
       "peer": true
     },
+    "node_modules/ts-pattern": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/ts-pattern/-/ts-pattern-5.7.1.tgz",
+      "integrity": "sha512-EGs8PguQqAAUIcQfK4E9xdXxB6s2GK4sJfT/vcc9V1ELIvC4LH/zXu2t/5fajtv6oiRCxdv7BgtVK3vWgROxag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "peer": true
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
@@ -5027,6 +6352,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.74",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.74.tgz",
+      "integrity": "sha512-J8poo92VuhKjNknViHRAIuuN6li/EwFbAC8OedzI8uxpEPGiXHGQu9wemIAioIpqgfB4SySaJhdk0mH5Y4ICBg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -11,15 +11,15 @@
     "prettier": "prettier --write .",
     "sync": "npx tsx scripts/sync-types.ts",
     "prebuild": "npm run prettier",
-    "deploy": "npx tsx scripts/deploy.ts"
+    "deploy": "npx tsx scripts/deploy.ts",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@hakit/components": "^5.0.9",
     "@hakit/core": "^5.0.9",
-    "framer-motion": "^12.7.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-error-boundary": "^6.0.0"
+    "react-error-boundary": "^5.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",
@@ -33,6 +33,8 @@
     "eslint": "^9.21.0",
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.19",
+    "eslint-plugin-react-dom": "^1.52.2",
+    "eslint-plugin-react-x": "^1.52.2",
     "globals": "^16.0.0",
     "node-scp": "^0.0.25",
     "prettier": "^3.5.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { HassConnect} from '@hakit/core';
+import { HassConnect } from '@hakit/core';
 import { CardBase, ThemeProvider } from '@hakit/components';
 import { ErrorBoundary } from 'react-error-boundary';
 import Dashboard from './Dashboard';
@@ -9,13 +9,8 @@ function App() {
   const hassUrl = import.meta.env.VITE_HA_URL;
   const hassToken = import.meta.env.VITE_HA_TOKEN;
 
-  if (!hassUrl || !hassToken) {
-    // Display a message if the environment variables are not set using HAKit component
-    return (
-      <CardBase>
-        Home Assistant URL or Token is not set. Please check your .env file.
-      </CardBase>
-    );
+  if (!hassUrl) {
+    return <CardBase>Home Assistant URL is not set. Please check your .env file.</CardBase>;
   }
 
   return (

--- a/src/Dashboard.tsx
+++ b/src/Dashboard.tsx
@@ -6,7 +6,7 @@ import OverviewCard from './components/OverviewCard';
 import QuickActionsPanel from './components/QuickActionsPanel';
 import { EntityName } from '@hakit/core';
 import type { Action } from './components/QuickActionsPanel';
-import DynamicEntityComponent from './components/registry/DynamicEntityComponent'; 
+import DynamicEntityComponent from './components/registry/DynamicEntityComponent';
 import { useMemo } from 'react';
 import ComponentRegistryProvider from './components/registry/ComponentRegistry';
 
@@ -16,19 +16,20 @@ const Dashboard = () => {
   const entities = useStore(state => state.entities);
 
   const quickActions: Action[] = useMemo(() => {
+    const domains = ['scene', 'script', 'light', 'switch', 'button'];
     return Object.entries(entities)
-      .filter(([entityId]) => entityId.startsWith('script.'))
+      .filter(([entityId]) => domains.some(domain => entityId.startsWith(`${domain}.`)))
       .map(([entityId]) => ({
-        type: 'script',
+        type: entityId.split('.')[0] as Action['type'],
         entityId: entityId as EntityName,
-        label: entityId.replace('script.', '').replace(/_/g, ' '),
-        icon: 'mdi:script'
+        label: entityId.split('.')[1].replace(/_/g, ' '),
+        icon: 'mdi:script',
       }));
   }, [entities]);
 
   return (
     <ComponentRegistryProvider>
-      <Column gap="md" style={{ padding: 'var(--ha-spacing-md)', minHeight: '100vh' }}>
+      <Column gap='md' style={{ padding: 'var(--ha-spacing-md)', minHeight: '100vh' }}>
         <GlobalInfoBar />
         <OverviewCard />
         <QuickActionsPanel actions={quickActions} />
@@ -41,7 +42,7 @@ const Dashboard = () => {
 
         {prioritizedContent.map(area =>
           area.area ? (
-            <Column key={area.area} gap="sm">
+            <Column key={area.area} gap='sm'>
               {area.entities.map(meta => (
                 <DynamicEntityComponent key={meta.entity_id} meta={meta} />
               ))}

--- a/src/components/AreaOverview.tsx
+++ b/src/components/AreaOverview.tsx
@@ -4,9 +4,9 @@ import RoomContextCard from './RoomContextCard';
 
 const AreaOverview = () => {
   const { areas } = useDashboard();
-  
+
   return (
-    <Column gap="var(--ha-spacing-md)">
+    <Column gap='md'>
       {areas.map(area => (
         <RoomContextCard key={area.area_id} areaId={area.area_id} />
       ))}

--- a/src/components/MediaPlayerControls.tsx
+++ b/src/components/MediaPlayerControls.tsx
@@ -1,21 +1,22 @@
 import { CardBase, MediaPlayerCard, Group } from '@hakit/components';
-import { EntityName, FilterByDomain, useEntity } from '@hakit/core';
+import { EntityName, useEntity } from '@hakit/core';
 
 interface MediaPlayerControlsProps {
-  entityId: FilterByDomain<EntityName, "media_player">;
+  entityId: EntityName;
 }
 
 const MediaPlayerControls = ({ entityId }: MediaPlayerControlsProps) => {
   const entity = useEntity(entityId);
-  
-  if (!entity) {
+  const domain = entityId.split('.')[0];
+
+  if (!entity || (domain !== 'media_player' && entity.attributes?.device_class !== 'media')) {
     return null;
   }
-  
+
   return (
     <CardBase>
-      <Group title={entity.attributes?.friendly_name || "Media Player"}>
-        <MediaPlayerCard entity={entityId} />
+      <Group title={entity.attributes?.friendly_name || 'Media Player'}>
+        <MediaPlayerCard entity={entityId as unknown as any} />
       </Group>
     </CardBase>
   );

--- a/src/components/OverviewCard.tsx
+++ b/src/components/OverviewCard.tsx
@@ -3,20 +3,19 @@ import { HassEntityWithService, EntityName, useHass } from '@hakit/core';
 
 const OverviewCard = () => {
   const { useStore } = useHass();
-  const allHassEntities = useStore((state) => state.entities);
+  const allHassEntities = useStore(state => state.entities);
 
-  const lightsOn = Object.values(allHassEntities).filter((entity) =>
-    entity && entity.entity_id.startsWith('light.') && entity.state === 'on'
+  const lightsOn = Object.values(allHassEntities).filter(
+    entity => entity && entity.entity_id.startsWith('light.') && entity.state === 'on'
   ) as HassEntityWithService<any>[];
 
-  const activePlayers = Object.values(allHassEntities).filter((entity) =>
-    entity &&
-    entity.entity_id.startsWith('media_player.') &&
-    entity.attributes &&
-    ['playing', 'paused', 'buffering', 'on'].includes(entity.state) &&
-    (entity.attributes.media_title ||
-      entity.attributes.media_artist ||
-      entity.attributes.app_name)
+  const activePlayers = Object.values(allHassEntities).filter(
+    entity =>
+      entity &&
+      entity.entity_id.startsWith('media_player.') &&
+      entity.attributes &&
+      ['playing', 'paused', 'buffering', 'on'].includes(entity.state) &&
+      (entity.attributes.media_title || entity.attributes.media_artist || entity.attributes.app_name)
   ) as HassEntityWithService<any>[];
 
   if (lightsOn.length === 0 && activePlayers.length === 0) {
@@ -25,16 +24,16 @@ const OverviewCard = () => {
 
   return (
     <CardBase>
-      <Group title="Home Overview">
+      <Group title='Home Overview'>
         {lightsOn.length > 0 && (
-          <Group title="Lights On">
-            <Row gap="var(--ha-spacing-md)" wrap="wrap">
-              {lightsOn.map((light) => (
+          <Group title='Lights On'>
+            <Row gap='md' wrap='wrap'>
+              {lightsOn.map(light => (
                 <ButtonCard
                   key={light.entity_id}
                   entity={light.entity_id as EntityName}
                   title={light.attributes?.friendly_name || light.entity_id.split('.')[1]}
-                  icon="mdi:lightbulb"
+                  icon='mdi:lightbulb'
                 />
               ))}
             </Row>
@@ -42,14 +41,14 @@ const OverviewCard = () => {
         )}
 
         {activePlayers.length > 0 && (
-          <Group title="Active Media">
-            <Row gap="var(--ha-spacing-md)" wrap="wrap">
-              {activePlayers.map((player) => (
+          <Group title='Active Media'>
+            <Row gap='md' wrap='wrap'>
+              {activePlayers.map(player => (
                 <ButtonCard
                   key={player.entity_id}
                   entity={player.entity_id as EntityName}
                   title={`${player.attributes?.media_title || player.attributes?.app_name || 'Unknown Media'}${player.attributes?.media_artist ? ` - ${player.attributes.media_artist}` : ''}`}
-                  icon="mdi:play-circle"
+                  icon='mdi:play-circle'
                 />
               ))}
             </Row>

--- a/src/components/QuickActionsPanel.tsx
+++ b/src/components/QuickActionsPanel.tsx
@@ -16,15 +16,10 @@ interface QuickActionsPanelProps {
 const QuickActionsPanel: React.FC<QuickActionsPanelProps> = ({ actions }) => {
   return (
     <CardBase>
-      <Group title="Quick Actions">
-        <Row wrap="wrap" gap="md">
-          {actions.map((action) => (
-            <ButtonCard
-              key={action.entityId}
-              entity={action.entityId}
-              title={action.label}
-              icon={action.icon}
-            />
+      <Group title='Quick Actions'>
+        <Row wrap='wrap' gap='md'>
+          {actions.map((action, i) => (
+            <ButtonCard key={action.entityId + '-' + i} entity={action.entityId} title={action.label} icon={action.icon} />
           ))}
         </Row>
       </Group>

--- a/src/components/RoomContextCard.tsx
+++ b/src/components/RoomContextCard.tsx
@@ -16,16 +16,11 @@ const RoomContextCard = ({ areaId }: RoomContextCardProps) => {
   return (
     <CardBase>
       <Group title={area.name}>
-        <Row wrap="wrap" gap="var(--ha-spacing-md)">
-          {entities.map((entity) => (
-            <ButtonCard
-              key={entity.entity_id}
-              entity={entity.entity_id as EntityName}
-            />
+        <Row wrap='wrap' gap='md'>
+          {entities.map(entity => (
+            <ButtonCard key={entity.entity_id} entity={entity.entity_id as EntityName} />
           ))}
-          {entities.length === 0 && (
-            <CardBase>No controllable devices in this room</CardBase>
-          )}
+          {entities.length === 0 && <em>No controllable devices in this room</em>}
         </Row>
       </Group>
     </CardBase>

--- a/src/components/layout/PageContainer.tsx
+++ b/src/components/layout/PageContainer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Column } from '@hakit/components';
 
 const PageContainer: React.FC<React.PropsWithChildren> = ({ children }) => (
-  <Column gap="var(--ha-spacing-md)" style={{ padding: 'var(--ha-spacing-md)', minHeight: '100vh' }}>
+  <Column gap='md' style={{ padding: 'var(--ha-spacing-md)', minHeight: '100vh' }}>
     {children}
   </Column>
 );

--- a/src/context/DashboardContext.tsx
+++ b/src/context/DashboardContext.tsx
@@ -34,7 +34,7 @@ type ComponentRegistryEntry = {
   types: EntityType[];
   tags?: string[];
   displayWhen: (meta: EntityMeta) => boolean;
-  component: ComponentType<any>;  // Updated to accept React components
+  component: ComponentType<any>; // Updated to accept React components
   props?: (meta: EntityMeta) => Record<string, any>;
 };
 
@@ -54,12 +54,11 @@ export const DashboardProvider = ({ children }: { children: ReactNode }) => {
   // Use proper hooks from HAKit
   const areas = useAreas();
   const { useStore } = useHass();
-  const allHassEntities = useStore((state) => state.entities);
-  
+  const allHassEntities = useStore(state => state.entities);
+
   // Initialize component registry with local state
-  const [componentRegistry, setComponentRegistry] = 
-    React.useState<Record<string, ComponentRegistryEntry>>({});
-  
+  const [componentRegistry, setComponentRegistry] = React.useState<Record<string, ComponentRegistryEntry>>({});
+
   // Get formatted areas from Home Assistant registry
   const formattedAreas = useMemo(() => {
     return Object.entries(areas || {}).map(([id, area]) => ({
@@ -68,40 +67,59 @@ export const DashboardProvider = ({ children }: { children: ReactNode }) => {
     }));
   }, [areas]);
 
-  // Get entities for a specific area
+  // Cache entities by area
+  const entitiesByArea = useMemo(() => {
+    const map: Record<string, Entity[]> = {};
+    Object.values(allHassEntities).forEach(entity => {
+      if (!entity || !entity.attributes?.area_id) return;
+      const area = entity.attributes.area_id;
+      if (!map[area]) {
+        map[area] = [];
+      }
+      map[area].push(entity as Entity);
+    });
+    return map;
+  }, [allHassEntities]);
+
   const getEntitiesInArea = (areaId: string): Entity[] => {
-    return Object.values(allHassEntities).filter(entity => {
-      if (!entity || !entity.attributes) return false;
-      // Compare the entity's area_id from attributes
-      return entity.attributes.area_id === areaId;
-    }) as HassEntityWithService<any>[];
+    return entitiesByArea[areaId] || [];
   };
-  
+
   // Helper function to determine entity type
   const getEntityType = (entityId: string): EntityType => {
     const domain = entityId.split('.')[0];
-    
+
     switch (domain) {
-      case 'light': return 'light';
-      case 'climate': return 'climate';
-      case 'media_player': return 'media';
-      case 'binary_sensor': return 'binary_sensor';
-      case 'sensor': return 'sensor';
-      case 'switch': return 'switch';
-      case 'cover': return 'cover';
-      case 'alarm_control_panel': return 'alarm';
-      case 'script': return 'script';
-      default: return 'other';
+      case 'light':
+        return 'light';
+      case 'climate':
+        return 'climate';
+      case 'media_player':
+        return 'media';
+      case 'binary_sensor':
+        return 'binary_sensor';
+      case 'sensor':
+        return 'sensor';
+      case 'switch':
+        return 'switch';
+      case 'cover':
+        return 'cover';
+      case 'alarm_control_panel':
+        return 'alarm';
+      case 'script':
+        return 'script';
+      default:
+        return 'other';
     }
   };
-  
+
   // Helper function to determine if an entity is active
   const isEntityActive = (entity: Entity): boolean => {
     if (!entity) return false;
-    
+
     const { entity_id, state } = entity;
     const domain = entity_id.split('.')[0];
-    
+
     switch (domain) {
       case 'light':
       case 'switch':
@@ -116,77 +134,77 @@ export const DashboardProvider = ({ children }: { children: ReactNode }) => {
         return state === 'on' || state === 'playing' || state === 'open';
     }
   };
-  
+
   // Helper function to get entity tags
   const getEntityTags = (entity: Entity): string[] => {
     const tags: string[] = [];
     const { entity_id, attributes } = entity;
     const domain = entity_id.split('.')[0];
-    
+
     tags.push(domain);
-    
+
     if (attributes?.device_class) {
       tags.push(attributes.device_class);
     }
-    
+
     // Add tags for specific conditions
     if (domain === 'binary_sensor' && entity.state === 'on') {
       if (attributes?.device_class === 'motion') tags.push('motion');
       if (attributes?.device_class === 'door') tags.push('door');
       if (attributes?.device_class === 'window') tags.push('window');
     }
-    
+
     return tags;
   };
-  
+
   // Generate entity metadata
   const entityMetadata = useMemo(() => {
     const metadata: EntityMeta[] = [];
     const now = new Date();
     const currentHour = now.getHours();
-    
+
     // Process each entity
     Object.values(allHassEntities).forEach(entity => {
       if (!entity || !entity.attributes || !entity.attributes.area_id) return;
-      
+
       const { entity_id, state, attributes } = entity;
       const domain = entity_id.split('.')[0];
       const type = getEntityType(entity_id);
       const isActive = isEntityActive(entity);
       const tags = getEntityTags(entity);
       const area = formattedAreas.find(a => a.area_id === attributes.area_id)?.name || null;
-      
+
       // Calculate base score
       let score = 0;
       const reasons: string[] = [];
-      
+
       // Core scoring logic
       if (isActive) {
         score += 30;
         reasons.push('Entity is active');
       }
-      
+
       // Entity type specific scoring
       if (domain === 'binary_sensor' && state === 'on') {
         score += 40;
         reasons.push('Active binary sensor');
-        
+
         if (attributes.device_class === 'motion') {
           score += 20;
           reasons.push('Motion detected');
         }
       }
-      
+
       if (domain === 'media_player' && ['playing', 'paused'].includes(state)) {
         score += 35;
         reasons.push('Media is playing or paused');
       }
-      
+
       if (domain === 'climate' && state !== 'off') {
         score += 25;
         reasons.push('Climate control is active');
       }
-      
+
       // Time-based scoring
       if (domain === 'light' && isActive) {
         const isDaytime = currentHour >= 7 && currentHour < 19;
@@ -195,7 +213,7 @@ export const DashboardProvider = ({ children }: { children: ReactNode }) => {
           reasons.push('Light is on during evening/night hours');
         }
       }
-      
+
       // Add to metadata collection
       metadata.push({
         entity_id,
@@ -205,24 +223,22 @@ export const DashboardProvider = ({ children }: { children: ReactNode }) => {
         tags,
         isActive,
         score,
-        reasons
+        reasons,
       });
     });
-    
+
     return metadata;
   }, [allHassEntities, formattedAreas]);
-  
+
   // Filter entities by minimum score
   const filteredEntities = useMemo(() => {
-    return entityMetadata
-      .filter(meta => meta.score > 0)
-      .sort((a, b) => b.score - a.score);
+    return entityMetadata.filter(meta => meta.score > 0).sort((a, b) => b.score - a.score);
   }, [entityMetadata]);
-  
+
   // Group by area and sort for prioritized content
   const prioritizedContent = useMemo(() => {
     const areaGroups: Record<string, EntityMeta[]> = {};
-    
+
     // Group by area
     filteredEntities.forEach(entity => {
       const areaKey = entity.area_id || 'noArea';
@@ -231,53 +247,52 @@ export const DashboardProvider = ({ children }: { children: ReactNode }) => {
       }
       areaGroups[areaKey].push(entity);
     });
-    
+
     // Calculate area scores (sum of entity scores)
     const areaScores = Object.entries(areaGroups).map(([areaKey, entities]) => {
       const areaScore = entities.reduce((sum, entity) => sum + entity.score, 0);
       const areaName = entities[0].area || null;
-      
+
       return {
         areaKey,
         areaName,
         score: areaScore,
-        entities
+        entities,
       };
     });
-    
+
     // Sort areas by score
     return areaScores
       .sort((a, b) => b.score - a.score)
       .map(area => ({
         area: area.areaName,
-        entities: area.entities.sort((a, b) => b.score - a.score)
+        entities: area.entities.sort((a, b) => b.score - a.score),
       }));
   }, [filteredEntities]);
-  
+
   // Register a new component in the registry
   const registerComponent = (id: string, config: ComponentRegistryEntry) => {
     setComponentRegistry(prev => ({
       ...prev,
-      [id]: config
+      [id]: config,
     }));
   };
-  
+
   // Memoize the context value
-  const value = useMemo(() => ({
-    areas: formattedAreas,
-    getEntitiesInArea,
-    entityMetadata,
-    filteredEntities,
-    prioritizedContent,
-    componentRegistry,
-    registerComponent
-  }), [formattedAreas, entityMetadata, filteredEntities, prioritizedContent, componentRegistry]);
-  
-  return (
-    <DashboardContext.Provider value={value}>
-      {children}
-    </DashboardContext.Provider>
+  const value = useMemo(
+    () => ({
+      areas: formattedAreas,
+      getEntitiesInArea,
+      entityMetadata,
+      filteredEntities,
+      prioritizedContent,
+      componentRegistry,
+      registerComponent,
+    }),
+    [formattedAreas, entityMetadata, filteredEntities, prioritizedContent, componentRegistry]
   );
+
+  return <DashboardContext.Provider value={value}>{children}</DashboardContext.Provider>;
 };
 
 export const useDashboard = () => {
@@ -291,35 +306,35 @@ export const useDashboard = () => {
 // Helper hooks for component registration and selection
 export const useRegisterComponent = (id: string, config: ComponentRegistryEntry) => {
   const { registerComponent } = useDashboard();
-  
+
   React.useEffect(() => {
     registerComponent(id, config);
-  }, [id, registerComponent]);
+  }, [id, config, registerComponent]);
 };
 
 export const useMatchingComponents = (meta: EntityMeta) => {
   const { componentRegistry } = useDashboard();
-  
+
   return useMemo(() => {
     return Object.entries(componentRegistry)
       .filter(([_, config]) => {
         // Check if component supports this entity type
         if (!config.types.includes(meta.type)) return false;
-        
+
         // Check if tags match (if specified)
         if (config.tags && config.tags.length > 0) {
           if (!config.tags.some(tag => meta.tags.includes(tag))) {
             return false;
           }
         }
-        
+
         // Call the displayWhen function
         return config.displayWhen(meta);
       })
       .map(([id, config]) => ({
         id,
         component: config.component,
-        props: config.props ? config.props(meta) : { entityId: meta.entity_id }
+        props: config.props ? config.props(meta) : { entityId: meta.entity_id },
       }));
   }, [componentRegistry, meta]);
 };

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -3,9 +3,6 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
 }
 
 /* Card and animation styles are now handled by HAKit components */


### PR DESCRIPTION
## Summary
- trim unused deps and align peer versions
- document required env vars
- improve quick action filtering and keys
- tidy room context card UI
- remove duplicate font rules
- memoise area lookups in DashboardContext
- relax media player guard

## Testing
- `npm run build`
- `npm run lint` *(fails: parsing errors and lint warnings)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_686855f5338483228f9a22d3e08a19f6